### PR TITLE
Track scsims v4 to fix the production app crash

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,6 @@
-streamlit==1.28.1
-scsims==3.0.4
+# scsims v4 modernizes the dependency stack so the app works on the
+# Python 3.11/3.12/3.13 venvs that Streamlit Community Cloud now ships.
+# Install directly from the v4 branch until 4.0.0 is published to PyPI;
+# after that, swap this for: scsims>=4.0
+scsims @ git+https://github.com/braingeneers/SIMS.git@v4
+streamlit>=1.36

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -64,8 +64,13 @@ if uploaded_file is not None:
                         cell_predictions = sims.predict(testdata, num_workers=0, batch_size=32)
                         st.session_state['run'] = True
                         st.caption("Predictions are done!")
-                        testdata.obs['cell_predictions'] = cell_predictions["first_pred"].values
-                        testdata.obs['confidence_score'] = cell_predictions["first_prob"].values
+                        # scsims.SIMS.predict() returns top-k predictions as
+                        # `pred_0..pred_{k-1}` and `prob_0..prob_{k-1}`. The
+                        # `first_pred`/`first_prob` aliases used here previously
+                        # were never produced by the library, so this line used
+                        # to KeyError on the first click of "Predict Cell Types".
+                        testdata.obs['cell_predictions'] = cell_predictions["pred_0"].values
+                        testdata.obs['confidence_score'] = cell_predictions["prob_0"].values
                         st.dataframe(testdata.obs)
                         data_as_csv = testdata.obs.to_csv(index=False).encode("utf-8")
 


### PR DESCRIPTION
The deployed app at sc-sims-app.streamlit.app has been failing on every recent reboot with:

  ModuleNotFoundError: No module named 'pkg_resources'
  ...
  File ".../lightning_utilities/core/imports.py", line 13, in <module>
    import pkg_resources

Root cause: scsims 3.0.4 (the previous pin) transitively pinned pytorch-lightning==2.0.2, which pulls lightning-utilities 0.8.0, which still does the legacy `import pkg_resources` from setuptools. `pkg_resources` was removed in setuptools 81 (mid-2025), and the Streamlit Cloud venv started installing setuptools >=81 sometime after that. The result is that the entire dependency stack pinned in scsims 3.0.x is now uninstallable on Streamlit Cloud.

Plus a second, latent bug that would have killed the app on the first click of "Predict Cell Types" even if the import had succeeded:

    cell_predictions["first_pred"]   # KeyError
    cell_predictions["first_prob"]   # KeyError

scsims.SIMS.predict() has *always* returned columns named pred_0/prob_0, not first_pred/first_prob. The streamlit_app.py was reaching for keys the library has never produced.

Fix:

- Bump scsims to v4 via the v4 branch on the SIMS repo. v4 modernizes the entire dependency stack: torch >= 2.2, lightning >= 2.2, torchmetrics >= 1.0, numpy >= 1.26, anndata >= 0.10. Resolves cleanly on Python 3.11/3.12/3.13 with current setuptools. After scsims 4.0.0 is published to PyPI, this requirements line should be replaced with `scsims>=4.0`.
- Bump streamlit to >=1.36 to drop the strict 1.28.1 pin (the old pin was mostly noise; scsims is the actual blocker).
- Fix the column references in streamlit_app.py to use the canonical pred_0 / prob_0 names that scsims has been producing the whole time.
- Add an explanatory comment so this doesn't regress.

Verified locally against scsims v4 + the shipped MGE_cortex.ckpt (34430 input genes, 15 cell-type classes):
- top-level imports succeed
- streamlit boots with no traceback
- predict path produces decoded cell-type strings ('MGE_LHX6/MAF', etc.)
- explainability path returns top-10 genes
- gene-mismatch zero-inflation still works (29430 missing genes silently zero-padded)